### PR TITLE
Fix typo in contact form error text

### DIFF
--- a/src/app/contacto/form-contacto.tsx
+++ b/src/app/contacto/form-contacto.tsx
@@ -81,7 +81,7 @@ export default function Contacto() {
         </div>
         {error && (
           <div className="text-red-500 text-sm">
-            Todos los campos son obligarorios
+            Todos los campos son obligatorios
           </div>
         )}
         {fail && (


### PR DESCRIPTION
## Summary
- fix a typo in the Contacto form error message

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f6f2313c832faba8bd2fd5590a09