### PR TITLE
Add Jest setup with basic utils tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'node',
+  testMatch: ['**/*.test.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,7 +60,10 @@
         "postcss": "^8",
         "tailwindcss": "^3.3.0",
         "typescript": "^5",
-        "vercel": "39.1.1"
+        "vercel": "39.1.1",
+        "@types/jest": "^29.5.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.1.1"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
@@ -61,6 +62,9 @@
     "postcss": "^8",
     "tailwindcss": "^3.3.0",
     "typescript": "^5",
-    "vercel": "39.1.1"
+    "vercel": "39.1.1",
+    "@types/jest": "^29.5.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.1"
   }
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,0 +1,21 @@
+import { getTextColor, getPagination } from './utils';
+
+describe('getTextColor', () => {
+  it('returns white text for dark background', () => {
+    expect(getTextColor('#000000')).toBe('#ffffff');
+  });
+
+  it('returns black text for light background', () => {
+    expect(getTextColor('#ffffff')).toBe('#000000');
+  });
+});
+
+describe('getPagination', () => {
+  it('calculates range for first page', () => {
+    expect(getPagination(0, 10)).toEqual({ from: 0, to: 9 });
+  });
+
+  it('calculates range for second page', () => {
+    expect(getPagination(1, 10)).toEqual({ from: 10, to: 19 });
+  });
+});


### PR DESCRIPTION
## Summary
- setup Jest with ts-jest
- provide unit tests for `getTextColor` and `getPagination`
- expose test command and devDependencies

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842f6e0a4c8832fb7e69cf11a6e39ed